### PR TITLE
Fix loading lib

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>bundleid</key>
-	<string>com.nba-scores.bjornelvar</string>
+	<string>com.nba_scores.bjornelvar</string>
 	<key>connections</key>
 	<dict>
 		<key>22EE12D6-D7AC-40AE-8B35-71927C146C70</key>
@@ -21,9 +21,9 @@
 		</array>
 	</dict>
 	<key>createdby</key>
-	<string>Bjorn Elvar</string>
+	<string>Bjorn Elvar (@verkfall)</string>
 	<key>description</key>
-	<string>Displays today's scores with stat leaders</string>
+	<string>Displays today's games with stat leaders</string>
 	<key>disabled</key>
 	<false/>
 	<key>name</key>
@@ -46,7 +46,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>keyword</key>
-				<string>nba</string>
+				<string>{var:scores_keyword}</string>
 				<key>queuedelaycustom</key>
 				<integer>3</integer>
 				<key>queuedelayimmediatelyinitially</key>
@@ -56,9 +56,10 @@
 				<key>queuemode</key>
 				<integer>1</integer>
 				<key>runningsubtext</key>
-				<string></string>
+				<string>Getting today's games…</string>
 				<key>script</key>
-				<string>python3 ./nba.py</string>
+				<string>export PYTHONPATH='./lib'
+python3 ./nba.py</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -66,7 +67,7 @@
 				<key>subtext</key>
 				<string></string>
 				<key>title</key>
-				<string></string>
+				<string>NBA Scores</string>
 				<key>type</key>
 				<integer>5</integer>
 				<key>withspace</key>
@@ -127,11 +128,31 @@
 		</dict>
 	</dict>
 	<key>userconfigurationconfig</key>
-	<array/>
-	<key>variablesdontexport</key>
-	<array/>
+	<array>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>nba</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>Scores Keyword</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>scores_keyword</string>
+		</dict>
+	</array>
 	<key>version</key>
-	<string>0.9.2</string>
+	<string>0.9.32</string>
 	<key>webaddress</key>
 	<string>igulker.xyz</string>
 </dict>


### PR DESCRIPTION
Looks like the `info.plist` you have in the repo is outdated from the workflow in the release.

This updates it, but has other fixes:

* Correctly load the `lib` directory. It was giving me an error due to missing `requests`.
* Adds a Placeholder Title so it shows up in Alfred results while typing (e.g. `nb`).
* Fills the “Please Wait” Subtext.
* Makes the keyword configurable by the user. It still defaults to `nba`
* Bumps the version.

[Packaged workflow for easy review.](https://github.com/bjornelvar/alfred_nba_scores/files/9854509/NBA.Scores.alfredworkflow.zip)
